### PR TITLE
Fixing a typo on one example in the README

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -14,7 +14,7 @@ The implementation idea comes from https://blog.gopheracademy.com/advent-2014/pa
 
 #### Example for parsing a file:
 ```	go
-f, _ := os.Open("pizza-functional.owl")
+f, err := os.Open("pizza-functional.owl")
 if err != nil {
 	panic(err)
 }


### PR DESCRIPTION
The source code indicated in the README is incorrect. 
The variable err is used without being declared.